### PR TITLE
[WIP] Redraw screen instead of clearing

### DIFF
--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -6,11 +6,11 @@ const BOOKMARKS_FILE: &str = "bookmarks.gph";
 
 macro_rules! dir_missing_fmt {
     () => {
-        "i\r\ni\r
-i\r\ni\x1b[91m{error}\x1b[0m\r
-i\r\niBookmarks can only be saved if {dir} exists.\r
-i\r\niRun this in your terminal to enable bookmarking:\r
-i\r\nimkdir -p {dir}"
+        "i\ni
+i\ni\x1b[91m{error}\x1b[0m
+i\niBookmarks can only be saved if {dir} exists.
+i\niRun this in your terminal to enable bookmarking:
+i\nimkdir -p {dir}"
     };
 }
 
@@ -24,7 +24,7 @@ pub fn as_raw_menu() -> String {
 
     let path = path.unwrap().join(BOOKMARKS_FILE);
     if !path.exists() {
-        out.push_str("iNo bookmarks yet.\r\ni\r\niUse <ctrl-s> to bookmark a page.\r\n");
+        out.push_str("iNo bookmarks yet.\ni\niUse <ctrl-s> to bookmark a page.\n");
         return out;
     }
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -72,7 +72,7 @@ i
 inum key    open/select link
 ienter      open current link
 iescape     cancel
-ictrl-c     cancel/quit
+ictrl-c     cancel
 i
 if or /     find link in page
 ip or k     select prev link

--- a/src/history.rs
+++ b/src/history.rs
@@ -6,11 +6,11 @@ const HISTORY_FILE: &str = "history.gph";
 
 macro_rules! file_missing_fmt {
     () => {
-        "i\r\ni\r
-i\r\ni\x1b[91m{error}\x1b[0m\r
-i\r\niHistory is only saved if {file} exists.\r
-i\r\niRun this in your terminal to activate automatic history saving:\r
-i\r\nimkdir -p {dir} && touch {file}"
+        "i\ni
+i\ni\x1b[91m{error}\x1b[0m
+i\niHistory is only saved if {file} exists.
+i\niRun this in your terminal to activate automatic history saving:
+i\nimkdir -p {dir} && touch {file}"
     };
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -245,8 +245,9 @@ impl Menu {
         }
         let &pos = self.links.get(self.link)?;
         Some(format!(
-            "{}\x1b[97;1m*\x1b[0m",
-            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
+            "{}\x1b[97;1m*\x1b[0m{}",
+            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16),
+            cursor::Hide
         ))
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -134,9 +134,13 @@ impl Menu {
             }
         };
 
+        let mut line_count = 0;
         for line in iter {
+            line_count += 1;
+            let mut line_size = 0;
             if !self.wide {
                 out.push_str(&indent);
+                line_size += indent.len();
             }
             if line.typ == Type::Info {
                 out.push_str("      ");
@@ -154,6 +158,8 @@ impl Menu {
                 out.push_str(&(line.link + 1).to_string());
                 out.push_str(".\x1b[0m ");
             }
+            line_size += 6;
+
             // truncate long lines, instead of wrapping
             let name = if line.name.len() > MAX_COLS {
                 line.name.chars().take(MAX_COLS).collect::<String>()
@@ -171,11 +177,25 @@ impl Menu {
                 typ if !typ.is_supported() => push!("107;91", name),
                 _ => push!("0", name),
             }
+
+            // clear rest of line
+            line_size += name.len();
+            out.push_str(&" ".repeat(cols - line_size)); // fill line
+
             out.push_str("\r\n");
         }
+
         if self.searching {
             out.push_str(&self.render_input());
         }
+
+        // clear remainder of screen
+        let blank_line = " ".repeat(cols);
+        for _ in 0..rows - line_count - 1 {
+            out.push_str(&blank_line);
+            out.push_str(&"\r\n");
+        }
+
         out
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -121,6 +121,22 @@ impl Menu {
         }
     }
 
+    /// The x and y position of a given link on screen.
+    fn screen_coords(&self, link: usize) -> Option<(u16, u16)> {
+        if !self.is_visible(link) {
+            return None;
+        }
+        let &pos = self.links.get(link)?;
+        let x = self.indent() + 1;
+        let y = if self.scroll > pos {
+            pos + 1
+        } else {
+            pos + 1 - self.scroll
+        };
+
+        Some((x as u16, y as u16))
+    }
+
     fn render_lines(&self) -> String {
         let mut out = String::new();
         let (cols, rows) = self.size;
@@ -230,12 +246,8 @@ impl Menu {
         if self.links.is_empty() || !self.is_visible(link) {
             return None;
         }
-        let &pos = self.links.get(link)?;
-        Some(format!(
-            "{} {}",
-            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16),
-            cursor::Hide
-        ))
+        let (x, y) = self.screen_coords(link)?;
+        Some(format!("{} {}", cursor::Goto(x, y), cursor::Hide))
     }
 
     /// Print this string to draw the cursor on screen.
@@ -244,10 +256,10 @@ impl Menu {
         if self.links.is_empty() {
             return None;
         }
-        let &pos = self.links.get(self.link)?;
+        let (x, y) = self.screen_coords(self.link)?;
         Some(format!(
             "{}\x1b[97;1m*\x1b[0m{}",
-            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16),
+            cursor::Goto(x, y),
             cursor::Hide
         ))
     }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -232,8 +232,9 @@ impl Menu {
         }
         let &pos = self.links.get(link)?;
         Some(format!(
-            "{} ",
-            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
+            "{} {}",
+            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16),
+            cursor::Hide
         ))
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -540,15 +540,18 @@ impl Menu {
 
     fn action_select_link(&mut self, link: usize) -> Action {
         if let Some(&pos) = self.links.get(link) {
-            if !self.is_visible(link) {
+            let old_link = self.link;
+            self.link = link;
+            if self.is_visible(link) {
+                self.reset_cursor(old_link)
+            } else {
                 if pos > 5 {
                     self.scroll = pos - 5;
                 } else {
                     self.scroll = 0;
                 }
+                Action::Redraw
             }
-            self.link = link;
-            Action::Redraw
         } else {
             Action::None
         }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -207,10 +207,6 @@ impl Menu {
             out.push_str("\r\n");
         }
 
-        if self.searching {
-            out.push_str(&self.render_input());
-        }
-
         // clear remainder of screen
         let blank_line = " ".repeat(cols);
         for _ in 0..rows - line_count - 1 {
@@ -261,25 +257,14 @@ impl Menu {
 
     /// User input field.
     fn render_input(&self) -> String {
-        format!(
-            "{}Find:\x1b[0m {}{}{}",
-            cursor::Goto(1, self.rows() as u16),
-            self.input,
-            cursor::Show,
-            clear::UntilNewline,
-        )
+        format!("Find: {}{}", self.input, cursor::Show)
     }
 
     fn redraw_input(&self) -> Action {
         if self.searching {
-            Action::Draw(self.render_input())
+            Action::Status(self.render_input())
         } else {
-            Action::Draw(format!(
-                "{}{}{}",
-                cursor::Goto(1, self.rows() as u16),
-                clear::CurrentLine,
-                cursor::Hide
-            ))
+            Action::Status(format!("{}", cursor::Hide))
         }
     }
 
@@ -538,6 +523,7 @@ impl Menu {
         }
     }
 
+    /// Select and optionally scroll to a link.
     fn action_select_link(&mut self, link: usize) -> Action {
         if let Some(&pos) = self.links.get(link) {
             let old_link = self.link;
@@ -666,7 +652,7 @@ impl Menu {
             }
             Key::Char('f') | Key::Ctrl('f') | Key::Char('/') | Key::Char('i') | Key::Ctrl('i') => {
                 self.searching = true;
-                Action::Redraw
+                self.redraw_input()
             }
             Key::Char('w') | Key::Ctrl('w') => {
                 self.wide = !self.wide;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,6 +1,7 @@
 use crate::gopher::{self, Type};
 use crate::ui::{Action, Key, View, MAX_COLS, SCROLL_LINES};
 use std::fmt;
+use termion::{clear, cursor};
 
 pub struct Menu {
     pub url: String,          // gopher url
@@ -232,7 +233,7 @@ impl Menu {
         let &pos = self.links.get(link)?;
         Some(format!(
             "{} ",
-            termion::cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
+            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
         ))
     }
 
@@ -245,7 +246,7 @@ impl Menu {
         let &pos = self.links.get(self.link)?;
         Some(format!(
             "{}\x1b[97;1m*\x1b[0m",
-            termion::cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
+            cursor::Goto((self.indent() + 1) as u16, (pos + 1) as u16)
         ))
     }
 
@@ -253,10 +254,10 @@ impl Menu {
     fn render_input(&self) -> String {
         format!(
             "{}Find:\x1b[0m {}{}{}",
-            termion::cursor::Goto(1, self.rows() as u16),
+            cursor::Goto(1, self.rows() as u16),
             self.input,
-            termion::cursor::Show,
-            termion::clear::UntilNewline,
+            cursor::Show,
+            clear::UntilNewline,
         )
     }
 
@@ -266,9 +267,9 @@ impl Menu {
         } else {
             Action::Draw(format!(
                 "{}{}{}",
-                termion::cursor::Goto(1, self.rows() as u16),
-                termion::clear::CurrentLine,
-                termion::cursor::Hide
+                cursor::Goto(1, self.rows() as u16),
+                clear::CurrentLine,
+                cursor::Hide
             ))
         }
     }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -93,12 +93,10 @@ impl Menu {
         }
     }
 
+    /// Find a link by its link index.
     fn link(&self, i: usize) -> Option<&Line> {
-        if let Some(line) = self.links.get(i) {
-            self.lines.get(*line)
-        } else {
-            None
-        }
+        let line = self.links.get(i)?;
+        self.lines.get(*line)
     }
 
     /// Is the given link visible on screen?
@@ -108,17 +106,14 @@ impl Menu {
 
     /// Where is the given link relative to the screen?
     fn link_visibility(&self, i: usize) -> Option<LinkPos> {
-        if let Some(&pos) = self.links.get(i) {
-            Some(if pos < self.scroll {
-                LinkPos::Above
-            } else if pos >= self.scroll + self.rows() - 1 {
-                LinkPos::Below
-            } else {
-                LinkPos::Visible
-            })
+        let &pos = self.links.get(i)?;
+        Some(if pos < self.scroll {
+            LinkPos::Above
+        } else if pos >= self.scroll + self.rows() - 1 {
+            LinkPos::Below
         } else {
-            None
-        }
+            LinkPos::Visible
+        })
     }
 
     /// The x and y position of a given link on screen.

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -477,7 +477,7 @@ impl Menu {
         }
 
         // if text is entered, find next match
-        if !self.input.is_empty() {
+        if self.searching && !self.input.is_empty() {
             if let Some(pos) = self.link_matching(self.link + 1, &self.input) {
                 return self.action_select_link(pos);
             } else {

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,7 +1,7 @@
 use crate::gopher::{self, Type};
 use crate::ui::{Action, Key, View, MAX_COLS, SCROLL_LINES};
 use std::fmt;
-use termion::{clear, cursor};
+use termion::cursor;
 
 pub struct Menu {
     pub url: String,          // gopher url
@@ -529,14 +529,22 @@ impl Menu {
             let old_link = self.link;
             self.link = link;
             if self.is_visible(link) {
-                self.reset_cursor(old_link)
+                if !self.input.is_empty() {
+                    Action::List(vec![self.redraw_input(), self.reset_cursor(old_link)])
+                } else {
+                    self.reset_cursor(old_link)
+                }
             } else {
                 if pos > 5 {
                     self.scroll = pos - 5;
                 } else {
                     self.scroll = 0;
                 }
-                Action::Redraw
+                if !self.input.is_empty() {
+                    Action::List(vec![self.redraw_input(), Action::Redraw])
+                } else {
+                    Action::Redraw
+                }
             }
         } else {
             Action::None

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,9 +1,6 @@
 use crate::gopher::{self, Type};
 use crate::ui::{Action, Key, View, MAX_COLS, SCROLL_LINES};
-use std::{
-    fmt,
-    io::{self, stdout, Write},
-};
+use std::fmt;
 
 pub struct Menu {
     pub url: String,          // gopher url

--- a/src/text.rs
+++ b/src/text.rs
@@ -94,8 +94,7 @@ impl View for Text {
         let indent = if cols >= longest && cols - longest <= 6 {
             String::from("")
         } else if cols >= longest {
-            let left = (cols - longest) / 2;
-            " ".repeat(left)
+            " ".repeat((cols - longest) / 2)
         } else {
             String::from("")
         };
@@ -117,6 +116,7 @@ impl View for Text {
                 out.push_str(&indent);
                 line_size += indent.len();
             }
+            let line = line.trim_end();
             out.push_str(line);
             line_size += line.len();
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -105,16 +105,34 @@ impl View for Text {
             .skip(self.scroll)
             .take(rows - 1);
 
+        let mut lines = 0;
+
         for line in iter {
+            lines += 1;
             if line == ".\r" {
                 continue;
             }
+            let mut line_size = 0;
             if !self.wide {
                 out.push_str(&indent);
+                line_size += indent.len();
             }
             out.push_str(line);
+            line_size += line.len();
+
+            // clear rest of line
+            out.push_str(&" ".repeat(cols - line_size)); // fill line
+
             out.push_str("\r\n");
         }
+
+        // clear remainder of screen
+        let blank_line = " ".repeat(cols);
+        for _ in 0..rows - lines - 1 {
+            out.push_str(&blank_line);
+            out.push_str(&"\r\n");
+        }
+
         out
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -121,7 +121,9 @@ impl View for Text {
             line_size += line.len();
 
             // clear rest of line
-            out.push_str(&" ".repeat(cols - line_size)); // fill line
+            if cols > line_size {
+                out.push_str(&" ".repeat(cols - line_size)); // fill line
+            }
 
             out.push_str("\r\n");
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -413,6 +413,11 @@ impl UI {
             Action::Keypress(Key::Esc) => {}
             Action::Error(e) => return Err(error!(e)),
             Action::Redraw => self.dirty = true,
+            Action::Draw(s) => {
+                let mut out = self.out.borrow_mut();
+                out.write_all(s.as_ref());
+                out.flush();
+            }
             Action::Open(title, url) => self.open(&title, &url)?,
             Action::Prompt(query, fun) => {
                 if let Some(response) = self.prompt(&query) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -216,7 +216,7 @@ impl UI {
                     termion::cursor::Hide,
                     label,
                     ".".repeat(i),
-                    termion::clear::AfterCursor,
+                    termion::clear::UntilNewline,
                     color::Fg(color::Reset),
                     termion::cursor::Show,
                 );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -77,13 +77,22 @@ impl UI {
                 termion::cursor::Hide,
                 screen,
             );
-            if status.len() > 0 {
+            if status.is_empty() {
                 write!(
                     out,
                     "{}{}{}",
                     termion::cursor::Goto(1, self.rows()),
+                    termion::cursor::Hide,
+                    termion::clear::CurrentLine,
+                );
+            } else {
+                write!(
+                    out,
+                    "{}{}{}{}",
+                    termion::cursor::Goto(1, self.rows()),
                     status,
-                    termion::cursor::Show,
+                    termion::cursor::Hide,
+                    termion::clear::UntilNewline,
                 );
             }
             out.flush();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -66,9 +66,9 @@ impl UI {
     }
 
     pub fn draw(&mut self) {
+        let status = self.render_status();
         if self.dirty {
             let screen = self.render();
-            let status = self.render_status();
             let mut out = self.out.borrow_mut();
             write!(
                 out,
@@ -81,7 +81,6 @@ impl UI {
             out.flush();
             self.dirty = false;
         } else {
-            let status = self.render_status();
             let mut out = self.out.borrow_mut();
             out.write_all(status.as_ref());
             out.flush();
@@ -91,7 +90,12 @@ impl UI {
     pub fn update(&mut self) {
         let action = self.process_page_input();
         if let Err(e) = self.process_action(action) {
-            self.set_status(format!("{}{}", color::Fg(color::LightRed), e));
+            self.set_status(format!(
+                "{}{}{}",
+                color::Fg(color::LightRed),
+                e,
+                termion::cursor::Hide
+            ));
         }
     }
 
@@ -252,7 +256,8 @@ impl UI {
 
     fn render_status(&self) -> String {
         format!(
-            "{}{}{}{}",
+            "{}{}{}{}{}",
+            termion::cursor::Hide,
             termion::cursor::Goto(1, self.rows()),
             termion::clear::CurrentLine,
             self.status,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -89,6 +89,7 @@ impl UI {
 
     pub fn update(&mut self) {
         let action = self.process_page_input();
+        self.status.clear();
         if let Err(e) = self.process_action(action) {
             self.set_status(format!(
                 "{}{}{}",
@@ -392,14 +393,6 @@ impl UI {
     }
 
     fn process_action(&mut self, action: Action) -> Result<()> {
-        // track if the status line was cleared in this update cycle
-        let cleared = if !self.status.is_empty() {
-            self.status.clear();
-            true
-        } else {
-            false
-        };
-
         match action {
             Action::List(actions) => {
                 for action in actions {
@@ -407,9 +400,7 @@ impl UI {
                 }
             }
             Action::Keypress(Key::Ctrl('c')) => {
-                if !cleared {
-                    self.running = false
-                }
+                self.status = "\x1b[90m(Use q to quit)\x1b[0m".into()
             }
             Action::Keypress(Key::Esc) => {}
             Action::Error(e) => return Err(error!(e)),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,13 +72,20 @@ impl UI {
             let mut out = self.out.borrow_mut();
             write!(
                 out,
-                "{}{}{}{}{}",
-                termion::clear::All,
+                "{}{}{}",
                 termion::cursor::Goto(1, 1),
                 termion::cursor::Hide,
                 screen,
-                status,
             );
+            if status.len() > 0 {
+                write!(
+                    out,
+                    "{}{}{}",
+                    termion::cursor::Goto(1, self.rows()),
+                    status,
+                    termion::cursor::Show,
+                );
+            }
             out.flush();
             self.dirty = false;
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -401,6 +401,11 @@ impl UI {
         };
 
         match action {
+            Action::List(actions) => {
+                for action in actions {
+                    self.process_action(action);
+                }
+            }
             Action::Keypress(Key::Ctrl('c')) => {
                 if !cleared {
                     self.running = false

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -1,4 +1,5 @@
 use crate::ui::Key;
+use std::fmt;
 
 pub enum Action {
     None,                                              // do nothing
@@ -9,4 +10,26 @@ pub enum Action {
     Status(String),                                    // set the "status" line to something
     Prompt(String, Box<dyn FnOnce(String) -> Action>), // query string, callback on success
     Error(String),                                     // error message
+}
+
+impl fmt::Debug for Action {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::None => write!(f, "None"),
+            Action::Open(title, url) => write!(f, "Open: {}, {}", title, url),
+            Action::Keypress(key) => write!(f, "Keypress: {:?}", key),
+            Action::Redraw => write!(f, "Redraw"),
+            Action::Draw(s) => write!(f, "Draw: {:?}", s),
+            Action::Status(s) => write!(f, "Status: {}", s),
+            Action::Prompt(s, _) => write!(f, "Prompt: {}", s),
+            Action::List(li) => {
+                write!(f, "List: \n");
+                for a in li {
+                    write!(f, "{:?}", a);
+                }
+                Ok(())
+            }
+            Action::Error(s) => write!(f, "Error: {}", s),
+        }
+    }
 }

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -9,6 +9,7 @@ pub enum Action {
     Draw(String),                                      // draw something on screen
     Status(String),                                    // set the "status" line to something
     Prompt(String, Box<dyn FnOnce(String) -> Action>), // query string, callback on success
+    List(Vec<Action>),                                 // do more than one action
     Error(String),                                     // error message
 }
 

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -5,6 +5,7 @@ pub enum Action {
     Open(String, String),                              // open(title, url)
     Keypress(Key),                                     // unknown keypress
     Redraw,                                            // redraw everything
+    Draw(String),                                      // draw something on screen
     Prompt(String, Box<dyn FnOnce(String) -> Action>), // query string, callback on success
     Error(String),                                     // error message
 }

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -6,6 +6,7 @@ pub enum Action {
     Keypress(Key),                                     // unknown keypress
     Redraw,                                            // redraw everything
     Draw(String),                                      // draw something on screen
+    Status(String),                                    // set the "status" line to something
     Prompt(String, Box<dyn FnOnce(String) -> Action>), // query string, callback on success
     Error(String),                                     // error message
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ macro_rules! log {
             .create(true)
             .open("phetch.log")
         {
+            use std::io::prelude::*;
             file.write($e.as_ref());
             file.write(b"\n");
         }


### PR DESCRIPTION
Trying to fix screen flicker on slower computers (RPi, Win10 w/ WSL).

I think the solution is to just re-draw the entire screen on every tick and fill in unused space, rather than clear everything then just draw what's new.  So that's what I'm trying.

---

Update: Didn't work, so now we are manually clearing and drawing the cursor (`*`) when we need to. Everything is much faster but text views and raw views are broken.

---

Update: Now they're fixed. Testing on WSL and RPi shortly.

---

Update: 🐰 