### PR TITLE
Basic text wrapping of long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ the gophersphere.
         -o, --tor              Use local Tor proxy to open all pages
         -S, -O                 Disable TLS or Tor
 
+        -w, --wrap COLUMN      Wrap long lines in "text" views at COLUMN.
         -m, --media PROGRAM    Use to open media files. Default: mpv
         -M, --no-media         Just download media files, don't download
 

--- a/doc/phetch.1
+++ b/doc/phetch.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "PHETCH" "1" "2020-11-11"
+.TH "PHETCH" "1" "2020-11-14"
 .P
 .SH NAME
 .P
@@ -98,6 +98,11 @@ Use \fIFILE\fR instead of \fI~/.config/phetch/phetch.conf\fR
 \fB-C\fR, \fB--no-config\fR
 .RS 4
 Do not use any config file.
+.P
+.RE
+\fB-e\fR, \fB--encoding\fR \fIENCODING\fR
+.RS 4
+Render text views in CP437 or UTF8 (default) encoding.
 .P
 .RE
 \fB-h\fR, \fB--help\fR
@@ -310,6 +315,12 @@ media mpv
 
 # Use emoji indicators for TLS & Tor\&.
 emoji no
+
+# Encoding\&. Only CP437 and UTF8 are supported\&.
+encoding utf8
+
+# Wrap text at N columns\&. 0 = off (--wrap)
+wrap 0
 .fi
 .RE
 .P

--- a/doc/phetch.1
+++ b/doc/phetch.1
@@ -72,6 +72,12 @@ Tor default of 127.0.0.1:9050.
 Disable Tor.
 .P
 .RE
+\fB-w\fR, \fB--wrap\fR \fICOLUMN\fR
+.RS 4
+Wrap long lines in Gopher "text" views at \fICOLUMN\fR.
+Default: 0 (off)
+.P
+.RE
 \fB-m\fR, \fB--media\fR \fIPATH\fR
 .RS 4
 Use program at \fIPATH\fR to open media files (movies and sounds).

--- a/doc/phetch.1.md
+++ b/doc/phetch.1.md
@@ -49,6 +49,10 @@ If no URL is given, however, *phetch* will launch and open its default
 *-O*, *--no-tor*
 	Disable Tor.
 
+*-w*, *--wrap* _COLUMN_
+	Wrap long lines in Gopher "text" views at _COLUMN_.
+	Default: 0 (off)
+
 *-m*, *--media* _PATH_
 	Use program at _PATH_ to open media files (movies and sounds).
 	Default: mpv

--- a/doc/phetch.1.md
+++ b/doc/phetch.1.md
@@ -224,6 +224,9 @@ emoji no
 
 # Encoding. Only CP437 and UTF8 are supported.
 encoding utf8
+
+# Wrap text at N columns. 0 = off (--wrap)
+wrap 0
 ```
 
 # MEDIA PLAYER SUPPORT

--- a/src/args.rs
+++ b/src/args.rs
@@ -163,6 +163,17 @@ pub fn parse<T: AsRef<str>>(args: &[T]) -> Result<Config, ArgError> {
                 set_notor = true;
                 cfg.tor = false;
             }
+            "-w" | "--wrap" | "-wrap" => {
+                if let Some(column) = iter.next() {
+                    if let Ok(col) = column.as_ref().parse() {
+                        cfg.wrap = col;
+                    } else {
+                        return Err(ArgError::new("--wrap expects a COLUMN arg"));
+                    }
+                } else {
+                    return Err(ArgError::new("--wrap expects a COLUMN arg"));
+                }
+            }
             "-m" | "--media" | "-media" => {
                 if set_nomedia {
                     return Err(ArgError::new("can't set both --media and --no-media"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,8 @@ pub struct Config {
     pub encoding: Encoding,
     /// UI mode. Can't be set in conf file.
     pub mode: ui::Mode,
+    /// Column to wrap lines. 0 = off
+    pub wrap: usize,
 }
 
 impl Default for Config {
@@ -85,6 +87,7 @@ impl Default for Config {
             media: Some(DEFAULT_MEDIA_PLAYER.into()),
             encoding: Encoding::default(),
             mode: ui::Mode::default(),
+            wrap: 0,
         }
     }
 }
@@ -151,6 +154,16 @@ fn parse(text: &str) -> Result<Config> {
             "tls" => cfg.tls = to_bool(val)?,
             "tor" => cfg.tor = to_bool(val)?,
             "wide" => cfg.wide = to_bool(val)?,
+            "wrap" => {
+                if let Ok(num) = val.parse() {
+                    cfg.wrap = num;
+                } else {
+                    return Err(error!(
+                        "`wrap` expects a number value on line {}: {}",
+                        linenum, val
+                    ));
+                }
+            }
             "media" => {
                 cfg.media = match val.to_lowercase().as_ref() {
                     "false" | "none" => None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ emoji no
 
 # Encoding. Only CP437 and UTF8 are supported.
 encoding utf8
+
+# Wrap text at N columns. 0 = off (--wrap)
+wrap 0
 ";
 
 /// Not all the config options are available in the phetch.conf. We

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use std::{borrow::Cow, io::Result};
 
 /// Encoding of Gopher response. Only UTF8 and CP437 are supported.
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -25,6 +25,19 @@ impl Encoding {
                 Ok(Encoding::CP437)
             }
             _ => Err(error!("Expected CP437 or UTF8 encoding")),
+        }
+    }
+
+    /// Convert `response` into a String according to `encoding`.
+    pub fn encode<'res>(&self, response: &'res [u8]) -> Cow<'res, str> {
+        if matches!(self, Encoding::CP437) {
+            let mut converted = String::with_capacity(response.len());
+            for b in response {
+                converted.push_str(cp437::convert_byte(&b));
+            }
+            Cow::from(converted)
+        } else {
+            String::from_utf8_lossy(response)
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,7 @@ Options:
     -o, --tor              Use local Tor proxy to open all pages
     -S, -O                 Disable TLS or Tor
 
+    -w, --wrap COLUMN      Wrap long lines in \"text\" views at COLUMN.
     -m, --media PROGRAM    Use to open media files. Default: mpv
     -M, --no-media         Just download media files, don't download
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -275,4 +275,45 @@ mod test {
         assert!(res.contains("Ω"));
         assert!(res.contains("Θ"));
     }
+
+    #[test]
+    fn test_wrapping() {
+        let text = "regular line
+really really really really really really really really really really long line
+super duper extra scooper hoopa loopa double doopa maxi paxi giga baxi very very long line
+Qua nova re oblata omnis administratio belliconsistit militesque aversi a proelio ad studium audiendi et cognoscendi feruntur ubi hostes ad legatosexercitumque pervenerunt universi se ad pedes proiciunt orant ut adventus Caesaris expectetur captamsuam urbem videre...
+really really really really really really really really really kinda-but-not-really long line
+another regular line
+        ";
+
+        let lines = wrap_lines(text, 70);
+
+        assert_eq!("regular line", lines[0]);
+        assert_eq!(
+            "really really really really really really really really really really",
+            lines[1].trim()
+        );
+        assert_eq!("long line", lines[2].trim());
+        assert_eq!("very very long line", lines[4].trim());
+
+        assert_eq!(
+            "Qua nova re oblata omnis administratio belliconsistit militesque",
+            lines[5].trim()
+        );
+        assert_eq!(
+            "aversi a proelio ad studium audiendi et cognoscendi feruntur ubi",
+            lines[6].trim()
+        );
+        assert_eq!(
+            "hostes ad legatosexercitumque pervenerunt universi se ad pedes",
+            lines[7].trim()
+        );
+        assert_eq!(
+            "really really really really really really really really really kinda-",
+            lines[10].trim()
+        );
+        assert_eq!("but-not-really long line", lines[11].trim());
+
+        assert_eq!(13, lines.len());
+    }
 }


### PR DESCRIPTION
This adds fairly dumb text wrapping to long lines in "text" views.

It's off by default but can be enabled with `--wrap NUM` or the `wrap NUM` config file option. 

Will only work in UTF8 encoding.

- [x] `--wrap` flag
- [x] `--wrap` flag docs
- [x] `wrap` config option
- [x] `wrap` config option docs
- [x] basic text wrapping
- [x] less stupid text wrapping (look for `-` or ` ` to wrap at)
- [ ] ~error when trying to use with non-UTF8 encoding~ _wrapping works for cp437 too_